### PR TITLE
webpack-dev-server: fix config issue

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,7 @@ module.exports = {
         new ExtractTextPlugin('styles.css')
     ],
     devServer: {
-        contentBase: './src/assets',
+        contentBase: './build',
         stats: 'minimal'
     },
     resolve: {


### PR DESCRIPTION
Without that change, `npm start` doesn't work right for me, and shows "Cannot GET /" in reply to any HTTP response.