### PR TITLE
Image handling fixes for Instead-js

### DIFF
--- a/src/app/ui/parse_image.js
+++ b/src/app/ui/parse_image.js
@@ -16,44 +16,58 @@ function parseCompositePart(image) {
     }
     var pImg = image;
     var imageParts = [];
-    var pStyle = '';
+    var pStyle = 'position:absolute;';
     var pMargins;
     if (image.indexOf('@') !== -1 ) {
         imageParts = image.split('@');
         pImg = imageParts[0];
         pMargins = imageParts[1].match(/(\d+),(\d+)/);
-        pStyle = 'left:' + pMargins[1] + 'px;top:' + pMargins[2] + 'px;';
+        pStyle += 'left:' + pMargins[1] + 'px;top:' + pMargins[2] + 'px;';
+    } else {
+        pStyle += 'left: 0; top: 0;';
     }
-    return '<img style="position:absolute;' + pStyle + '" src="' + Game.fileURL(pImg) + '"/>';
+    // Parse pseudo-images (box, blank)
+    if (pImg.indexOf('box') === 0 || pImg.indexOf('blank') === 0) {
+        return pImg.replace(/(box|blank):(.+)/, function() {
+            var args = Array.prototype.slice.call(arguments);
+            args.unshift(pStyle);
+            return parseEmptyImage.apply(undefined,args);
+        });
+    }
+    return '<img style="' + pStyle + '" src="' + Game.fileURL(pImg) + '"/>';
+}
+
+function parseEmptyImage(style, fullReplaceString, box, params) {
+    var d = params.split(',');
+    var imgSize = d[0].match(/(\d+)x(\d+)/);
+    var eStyle = style + 'width:' + imgSize[1] + 'px;' +
+        'height:' + imgSize[2] + 'px;';
+    if (d[1]) {
+        eStyle += 'background-color:' + d[1] + ';';
+    }
+    if (d[2]) {
+        eStyle += 'opacity:' + (d[2] / 256) + ';';
+    }
+    eStyle += 'display:inline-block;';
+    return '<div style="' + eStyle + '"></div>';
 }
 
 
-function parseImg(fullString, img) {
+function parseImg(fullString, img, style) {
     var image = img;
-    var style = 'max-width: 100%;';
     var parsedImg = '';
-
-    function parseEmptyImage(fullReplaceString, box, params) {
-        var d = params.split(',');
-        var imgSize = d[0].match(/(\d+)x(\d+)/);
-        var eStyle = style + 'width:' + imgSize[1] + 'px;' +
-                'height:' + imgSize[2] + 'px;';
-        if (d[1]) {
-            eStyle += 'background-color:' + d[1] + ';';
-        }
-        if (d[2]) {
-            eStyle += 'opacity:' + (d[2] / 256) + ';';
-        }
-        eStyle += 'display:inline-block;';
-        return '<div style="' + eStyle + '"></div>';
-    }
+    style = style? style : 'max-width: 100%;';
 
     if (Sprite.is(img)) {
         return Sprite.asImage(img);
     }
     // Parse pseudo-images (box, blank)
     if (img.indexOf('box') === 0 || img.indexOf('blank') === 0) {
-        return img.replace(/(box|blank):(.+)/, parseEmptyImage);
+        return img.replace(/(box|blank):(.+)/, function() {
+            var args = Array.prototype.slice.call(arguments);
+            args.unshift(style);
+            return parseEmptyImage.apply(undefined, args);
+        });
     }
     // parse padded images
     if (image.indexOf('pad') === 0) {


### PR DESCRIPTION
While working on my game, I found some issues with handling composite images in instead-js. 
These commits fix issues I have been able to detect.
Here is a code of a sample game, that demonstrates the issue:
```
-- $Name: Bug Test$
-- $Version: 1.0$

main = room {
    nam = 'main';
    pic = 'box:128x128,white,255;box:64x64,red,255@64,0;box:64x64,green,255@64,64;box:64x64,blue,255@0,64;box:64x64,cyan,255';
    dsc = [[Эта игра демонстрирует баг в Instead-js. ]];
}
```

Here is how the picture looks in main Instead
![instead](https://user-images.githubusercontent.com/8182459/50490143-e2b31b80-0a24-11e9-87d5-d793462237d5.png)

Here is how it looks without fixes in Instead-js:
![instead-js-no-fix](https://user-images.githubusercontent.com/8182459/50490166-01191700-0a25-11e9-8d12-fa1864824161.png)

Here is how it looks with fixes in Instead-js:
![instead-js-fix](https://user-images.githubusercontent.com/8182459/50490179-12faba00-0a25-11e9-8b49-40dc200f5570.png)
